### PR TITLE
Use Jenkinsfile runner with fixed plugins

### DIFF
--- a/runTests.sh
+++ b/runTests.sh
@@ -13,7 +13,7 @@ pushd test-project
 docker run -v //var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace -v /tmp \
  -e BRANCH_NAME=master \
  -e CASC_JENKINS_CONFIG=/workspace/jenkins.yml -e HOST=$(hostname) \
- ppiper/jenkinsfile-runner
+ ppiper/jenkinsfile-runner:fixed-plugins
 
 popd
 


### PR DESCRIPTION
If we merge all "Use Jenkinsfile runner with fixed plugins" PRs, we can unfix the plugins on jenkins master and the tests still run. Downside: We might stay on this fixed runner forever..