### PR TITLE
Update branch detection for `master`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         docker tag ppiper/node-browsers:${{ matrix.base-image-tag }} ppiper/node-browsers:latest
         docker tag ghcr.io/sap/ppiper-node-browsers:${{ matrix.base-image-tag }} ghcr.io/sap/ppiper-node-browsers:latest
     - name: Push
-      if: ${{ github.ref == 'ref/head/master' }}
+      if: ${{ github.ref == 'refs/heads/master' }}
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
         echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin


### PR DESCRIPTION
It seems like the ref name changed, so currently we can't detect if we're on `master`.

cf https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#contexts