### PR TITLE
Set necessary flags for headless mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     ln -s /usr/bin/chromium /usr/bin/google-chrome
 
+ENV CHROMIUM_FLAGS="--headless --no-sandbox --disable-dev-shm-usage --disable-gpu"
+
 # Workaround for https://npm.sap.com issue with open SSL in Debian Buster
 RUN CIPHERS="$(openssl ciphers)" && sed -i "s/DEFAULT@SECLEVEL=2/$CIPHERS:DH-RSA-AES256-SHA256/g" /etc/ssl/openssl.cnf
 


### PR DESCRIPTION
Without these flags the user has to set these in their comfiguration, e.g. karma.conf.js:
```js
    browsers: ['ChromeHeadlessCustom'],
    customLaunchers: {
      ChromeHeadlessCustom: {
        base: 'ChromeHeadless',
        flags: ['--no-sandbox', '--disable-dev-shm-usage']
      }
    },
```

As this image is intended for automation and will always run in headless mode, we should set these flags for a simpler setup for the users.