### PR TITLE
Remove openssl workaround for npm.sap.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,4 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     ln -s /usr/bin/chromium /usr/bin/google-chrome
 
-# Workaround for https://npm.sap.com issue with open SSL in Debian Buster
-RUN CIPHERS="$(openssl ciphers)" && sed -i "s/DEFAULT@SECLEVEL=2/$CIPHERS:DH-RSA-AES256-SHA256/g" /etc/ssl/openssl.cnf
-
 USER node


### PR DESCRIPTION
Not needed anymore, see https://github.com/SAP/devops-docker-node-browsers/issues/48