### PR TITLE
chore: remove push to ghcr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,20 +26,15 @@ jobs:
     - name: Build
       run: |
         docker build --build-arg=BASE_IMAGE_TAG=${{ matrix.base-image-tag }} --build-arg=JAVA_VERSION=${{ steps.java_version.outputs.version }} --tag ppiper/node-browsers:${{ matrix.base-image-tag }} .
-        docker tag ppiper/node-browsers:${{ matrix.base-image-tag }} ghcr.io/sap/ppiper-node-browsers:${{ matrix.base-image-tag }}
     - name: Tag latest image
       if: ${{ matrix.base-image-tag == '24-bookworm' }}
       run: |
         docker tag ppiper/node-browsers:${{ matrix.base-image-tag }} ppiper/node-browsers:latest
-        docker tag ghcr.io/sap/ppiper-node-browsers:${{ matrix.base-image-tag }} ghcr.io/sap/ppiper-node-browsers:latest
     - name: Push
       if: ${{ github.ref == 'refs/heads/master' }}
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-        echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
         docker push ppiper/node-browsers:${{ matrix.base-image-tag }}
-        docker push ghcr.io/sap/ppiper-node-browsers:${{ matrix.base-image-tag }}
         if [ "${{ matrix.base-image-tag }}" == 24-bookworm ]; then
           docker push ppiper/node-browsers:latest
-          docker push ghcr.io/sap/ppiper-node-browsers:latest
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,18 +39,13 @@ jobs:
       - name: Build and push
         run: |
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
           docker build --build-arg=BASE_IMAGE_TAG=${{ matrix.base-image-tag }} --build-arg=JAVA_VERSION=${{ steps.java_version.outputs.version }} --tag ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} .
-          docker tag ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} ghcr.io/sap/ppiper-node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }}
           docker push ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }}
-          docker push ghcr.io/sap/ppiper-node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }}
       - name: Tag and push node 24 image
         if: ${{ matrix.base-image-tag == '24-bookworm' }}
         run: |
           docker tag ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} ppiper/node-browsers:${{ env.PIPER_version }}
-          docker tag ghcr.io/sap/ppiper-node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} ghcr.io/sap/ppiper-node-browsers:${{ env.PIPER_version }}
           docker push ppiper/node-browsers:${{ env.PIPER_version }}
-          docker push ghcr.io/sap/ppiper-node-browsers:${{ env.PIPER_version }}
       - uses: SAP/project-piper-action@master
         if: ${{ matrix.base-image-tag == '24-bookworm' }}
         with:


### PR DESCRIPTION
As we do not use this and the push needs a PAT,
which we don't want to provide anymore,
we deactivate this.