### PR TITLE
feat: add node 26-trixie to build and release matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm]
+        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm, 26-bookworm]
     steps:
     - uses: actions/checkout@master
     - name: Determine Java version
@@ -27,7 +27,7 @@ jobs:
       run: |
         docker build --build-arg=BASE_IMAGE_TAG=${{ matrix.base-image-tag }} --build-arg=JAVA_VERSION=${{ steps.java_version.outputs.version }} --tag ppiper/node-browsers:${{ matrix.base-image-tag }} .
     - name: Tag latest image
-      if: ${{ matrix.base-image-tag == '24-bookworm' }}
+      if: ${{ matrix.base-image-tag == '26-bookworm' }}
       run: |
         docker tag ppiper/node-browsers:${{ matrix.base-image-tag }} ppiper/node-browsers:latest
     - name: Push
@@ -35,6 +35,6 @@ jobs:
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
         docker push ppiper/node-browsers:${{ matrix.base-image-tag }}
-        if [ "${{ matrix.base-image-tag }}" == 24-bookworm ]; then
+        if [ "${{ matrix.base-image-tag }}" == 26-bookworm ]; then
           docker push ppiper/node-browsers:latest
         fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm, 26-bookworm]
+        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm, 26-trixie]
     steps:
     - uses: actions/checkout@master
     - name: Determine Java version
       id: java_version
       run: |
-        echo 'version=17' >> $GITHUB_OUTPUT
+        if [[ "${{ matrix.base-image-tag }}" == *trixie* ]]; then
+          echo 'version=21' >> $GITHUB_OUTPUT
+        else
+          echo 'version=17' >> $GITHUB_OUTPUT
+        fi
     - name: Test
       run: |
         chmod +x runTests.sh && ./runTests.sh ${{ matrix.base-image-tag }} ${{ steps.java_version.outputs.version }}
@@ -27,7 +31,7 @@ jobs:
       run: |
         docker build --build-arg=BASE_IMAGE_TAG=${{ matrix.base-image-tag }} --build-arg=JAVA_VERSION=${{ steps.java_version.outputs.version }} --tag ppiper/node-browsers:${{ matrix.base-image-tag }} .
     - name: Tag latest image
-      if: ${{ matrix.base-image-tag == '26-bookworm' }}
+      if: ${{ matrix.base-image-tag == '26-trixie' }}
       run: |
         docker tag ppiper/node-browsers:${{ matrix.base-image-tag }} ppiper/node-browsers:latest
     - name: Push
@@ -35,6 +39,6 @@ jobs:
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
         docker push ppiper/node-browsers:${{ matrix.base-image-tag }}
-        if [ "${{ matrix.base-image-tag }}" == 26-bookworm ]; then
+        if [ "${{ matrix.base-image-tag }}" == 26-trixie ]; then
           docker push ppiper/node-browsers:latest
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm]
+        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm, 26-bookworm]
     steps:
       - uses: actions/checkout@v3
       - name: Determine Java version
@@ -41,13 +41,13 @@ jobs:
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
           docker build --build-arg=BASE_IMAGE_TAG=${{ matrix.base-image-tag }} --build-arg=JAVA_VERSION=${{ steps.java_version.outputs.version }} --tag ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} .
           docker push ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }}
-      - name: Tag and push node 24 image
-        if: ${{ matrix.base-image-tag == '24-bookworm' }}
+      - name: Tag and push node 26 image
+        if: ${{ matrix.base-image-tag == '26-bookworm' }}
         run: |
           docker tag ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} ppiper/node-browsers:${{ env.PIPER_version }}
           docker push ppiper/node-browsers:${{ env.PIPER_version }}
       - uses: SAP/project-piper-action@master
-        if: ${{ matrix.base-image-tag == '24-bookworm' }}
+        if: ${{ matrix.base-image-tag == '26-bookworm' }}
         with:
           piper-version: latest
           command: githubPublishRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm, 26-bookworm]
+        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm, 26-trixie]
     steps:
       - uses: actions/checkout@v3
       - name: Determine Java version
         id: java_version
         run: |
-          echo 'version=17' >> $GITHUB_OUTPUT
+          if [[ "${{ matrix.base-image-tag }}" == *trixie* ]]; then
+            echo 'version=21' >> $GITHUB_OUTPUT
+          else
+            echo 'version=17' >> $GITHUB_OUTPUT
+          fi
       - name: Test
         run: |
           chmod +x runTests.sh && ./runTests.sh ${{ matrix.base-image-tag }} ${{ steps.java_version.outputs.version }}
@@ -42,12 +46,12 @@ jobs:
           docker build --build-arg=BASE_IMAGE_TAG=${{ matrix.base-image-tag }} --build-arg=JAVA_VERSION=${{ steps.java_version.outputs.version }} --tag ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} .
           docker push ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }}
       - name: Tag and push node 26 image
-        if: ${{ matrix.base-image-tag == '26-bookworm' }}
+        if: ${{ matrix.base-image-tag == '26-trixie' }}
         run: |
           docker tag ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} ppiper/node-browsers:${{ env.PIPER_version }}
           docker push ppiper/node-browsers:${{ env.PIPER_version }}
       - uses: SAP/project-piper-action@master
-        if: ${{ matrix.base-image-tag == '26-bookworm' }}
+        if: ${{ matrix.base-image-tag == '26-trixie' }}
         with:
           piper-version: latest
           command: githubPublishRelease

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ FROM node:$BASE_IMAGE_TAG
 
 ARG JAVA_VERSION
 
-RUN apt-get update && \
-    apt-get install -y chromium firefox-esr xvfb libxi6 libgbm1 libgconf-2-4 openjdk-"${JAVA_VERSION}"-jre && \
+RUN DEBIAN_VERSION=$(. /etc/os-release && echo "$VERSION_CODENAME") && \
+    if [ "$DEBIAN_VERSION" != "trixie" ]; then EXTRAS="libgconf-2-4"; fi && \
+    apt-get update && \
+    apt-get install -y chromium firefox-esr xvfb libxi6 libgbm1 $EXTRAS openjdk-"${JAVA_VERSION}"-jre && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     ln -s /usr/bin/chromium /usr/bin/google-chrome
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For specific Node versions, use the following tags:
 docker pull ppiper/node-browsers:20-bookworm
 docker pull ppiper/node-browsers:22-bookworm
 docker pull ppiper/node-browsers:24-bookworm
-docker pull ppiper/node-browsers:26-bookworm
+docker pull ppiper/node-browsers:26-trixie
 ```
 
 ## Build
@@ -40,10 +40,10 @@ docker pull ppiper/node-browsers:26-bookworm
 To build this image locally, open a terminal in the directory of the Dockerfile and run
 
 ```
-docker build --build-arg=BASE_IMAGE_TAG=26-bookworm -t ppiper/node-browsers .
+docker build --build-arg=BASE_IMAGE_TAG=26-trixie -t ppiper/node-browsers .
 ```
 
-Where the `BASE_IMAGE_TAG` can be set to `20-bookworm`, `22-bookworm`, `24-bookworm`, or `26-bookworm`.
+Where the `BASE_IMAGE_TAG` can be set to `20-bookworm`, `22-bookworm`, `24-bookworm`, or `26-trixie`.
 The given tag **must** exist in the [node](https://hub.docker.com/_/node) base image **and** use Debian GNU/Linux.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ docker pull ppiper/node-browsers:24-bookworm
 docker pull ppiper/node-browsers:26-trixie
 ```
 
+> **⚠️ Note:** The `26-trixie` image is based on Debian Trixie (13) which ships Java 21 by default instead of Java 17 (Bookworm). Please ensure your project is compatible with Java 21.
+
 ## Build
 
 To build this image locally, open a terminal in the directory of the Dockerfile and run

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This image is published to Docker Hub and can be pulled via the command
 docker pull ppiper/node-browsers
 ```
 
-The default tag `latest` contains Node 24.
+The default tag `latest` contains Node 26.
 
 For specific Node versions, use the following tags:
 
@@ -32,6 +32,7 @@ For specific Node versions, use the following tags:
 docker pull ppiper/node-browsers:20-bookworm
 docker pull ppiper/node-browsers:22-bookworm
 docker pull ppiper/node-browsers:24-bookworm
+docker pull ppiper/node-browsers:26-bookworm
 ```
 
 ## Build
@@ -39,10 +40,10 @@ docker pull ppiper/node-browsers:24-bookworm
 To build this image locally, open a terminal in the directory of the Dockerfile and run
 
 ```
-docker build --build-arg=BASE_IMAGE_TAG=24-bookworm -t ppiper/node-browsers .
+docker build --build-arg=BASE_IMAGE_TAG=26-bookworm -t ppiper/node-browsers .
 ```
 
-Where the `BASE_IMAGE_TAG` can be set to `20-bookworm`, `22-bookworm`, or `24-bookworm`.
+Where the `BASE_IMAGE_TAG` can be set to `20-bookworm`, `22-bookworm`, `24-bookworm`, or `26-bookworm`.
 The given tag **must** exist in the [node](https://hub.docker.com/_/node) base image **and** use Debian GNU/Linux.
 
 ## Usage


### PR DESCRIPTION
### Summary

Add Node.js 26 (Debian Trixie) as a new supported version in the CI/CD pipeline. The `latest` Docker tag now points to the Node 26 image, following the same promotion pattern used for previous major Node.js releases.

#### Changes

- Added `26-trixie` to the build and release matrix
- Used Debian Trixie (13) instead of Bookworm for Node 26, as Bookworm support is ending
- Workflows now conditionally pass Java 21 for Trixie-based images (Bookworm images remain on Java 17)
- Dockerfile detects the Debian version at build time and skips `libgconf-2-4` on Trixie (package was removed)
- Added a README warning about Java 21 in Trixie-based images

#### Reason

Current Node.js 26 is becoming the new LTS and thus should be added for future support.
https://nodejs.org/en/about/previous-releases

<img width="1008" height="939" alt="image" src="https://github.com/user-attachments/assets/0478cf92-683e-42d8-8adb-85be0d069fd9" />
