### PR TITLE
feat: add node 26 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base-image-tag: [22-bookworm, 24-bookworm]
+        base-image-tag: [22-bookworm, 24-bookworm, 26-trixie]
     steps:
     - uses: actions/checkout@master
     - name: Test
@@ -23,7 +23,7 @@ jobs:
       run: |
         docker build --build-arg=BASE_IMAGE_TAG=${{ matrix.base-image-tag }} --tag ppiper/node-browsers:${{ matrix.base-image-tag }} .
     - name: Tag latest image
-      if: ${{ matrix.base-image-tag == '24-bookworm' }}
+      if: ${{ matrix.base-image-tag == '26-trixie' }}
       run: |
         docker tag ppiper/node-browsers:${{ matrix.base-image-tag }} ppiper/node-browsers:latest
     - name: Push
@@ -31,6 +31,6 @@ jobs:
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
         docker push ppiper/node-browsers:${{ matrix.base-image-tag }}
-        if [ "${{ matrix.base-image-tag }}" == 24-bookworm ]; then
+        if [ "${{ matrix.base-image-tag }}" == 26-trixie ]; then
           docker push ppiper/node-browsers:latest
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base-image-tag: [22-bookworm, 24-bookworm]
+        base-image-tag: [22-bookworm, 24-bookworm, 26-trixie]
     steps:
       - uses: actions/checkout@v3
       - name: Test
@@ -37,13 +37,13 @@ jobs:
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
           docker build --build-arg=BASE_IMAGE_TAG=${{ matrix.base-image-tag }} --tag ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} .
           docker push ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }}
-      - name: Tag and push node 24 image
-        if: ${{ matrix.base-image-tag == '24-bookworm' }}
+      - name: Tag and push node 26 image
+        if: ${{ matrix.base-image-tag == '26-trixie' }}
         run: |
           docker tag ppiper/node-browsers:${{ env.PIPER_version }}-${{ matrix.base-image-tag }} ppiper/node-browsers:${{ env.PIPER_version }}
           docker push ppiper/node-browsers:${{ env.PIPER_version }}
       - uses: SAP/project-piper-action@master
-        if: ${{ matrix.base-image-tag == '24-bookworm' }}
+        if: ${{ matrix.base-image-tag == '26-trixie' }}
         with:
           piper-version: latest
           command: githubPublishRelease

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ This image is published to Docker Hub and can be pulled via the command
 docker pull ppiper/node-browsers
 ```
 
-The default tag `latest` contains Node 24.
+The default tag `latest` contains Node 26.
 
 For specific Node versions, use the following tags:
 
 ```
 docker pull ppiper/node-browsers:22-bookworm
 docker pull ppiper/node-browsers:24-bookworm
+docker pull ppiper/node-browsers:26-trixie
 ```
 
 ## Build
@@ -38,10 +39,10 @@ docker pull ppiper/node-browsers:24-bookworm
 To build this image locally, open a terminal in the directory of the Dockerfile and run
 
 ```
-docker build --build-arg=BASE_IMAGE_TAG=24-bookworm -t ppiper/node-browsers .
+docker build --build-arg=BASE_IMAGE_TAG=26-trixie -t ppiper/node-browsers .
 ```
 
-Where the `BASE_IMAGE_TAG` can be set to `22-bookworm` or `24-bookworm`.
+Where the `BASE_IMAGE_TAG` can be set to `22-bookworm`, `24-bookworm`, or `26-trixie`.
 The given tag **must** exist in the [node](https://hub.docker.com/_/node) base image **and** use Debian GNU/Linux.
 
 ## Usage


### PR DESCRIPTION
Adds Node 26 (26-trixie) as the new LTS version. The `latest` tag now points to Node 26.