### PR TITLE
chore: add pull_request trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - master
   schedule:
     - cron:  '0 0 * * 0'
   workflow_dispatch:


### PR DESCRIPTION
Enables the build workflow to run on pull requests targeting master, allowing fork contributors to see build results before merging.