### PR TITLE
ci: add permissions to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
     - cron:  '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 on: push
 name: Lint all Dockerfiles
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
         # https://github.com/hadolint/hadolint/wiki/DL3018
         # https://github.com/hadolint/hadolint/wiki/DL3015
         # https://github.com/hadolint/hadolint/wiki/DL3006 Make it work to build multiple node versions in one dockerfile via matrix build
-        args: --ignore DL3008 --ignore DL3013 --ignore DL3016 --ignore DL3018 --ignore DL3015 --ignore DL3006
+        args: --ignore DL3008 --ignore DL3013 --ignore DL3016 --ignore DL3018 --ignore DL3015 --ignore DL3006 --ignore SC1091

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     - cron:  '0 0 1 * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -2,6 +2,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add permission blocks to the workflows as preparation to switch to more restrictive GitHub-Token usage.