### PR TITLE
feat: add trixie variants for node 22 and 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm, 26-trixie]
+        base-image-tag: [20-bookworm, 22-bookworm, 22-trixie, 24-bookworm, 24-trixie, 26-trixie]
     steps:
     - uses: actions/checkout@master
     - name: Determine Java version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base-image-tag: [20-bookworm, 22-bookworm, 24-bookworm, 26-trixie]
+        base-image-tag: [20-bookworm, 22-bookworm, 22-trixie, 24-bookworm, 24-trixie, 26-trixie]
     steps:
       - uses: actions/checkout@v3
       - name: Determine Java version

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ For specific Node versions, use the following tags:
 ```
 docker pull ppiper/node-browsers:20-bookworm
 docker pull ppiper/node-browsers:22-bookworm
+docker pull ppiper/node-browsers:22-trixie
 docker pull ppiper/node-browsers:24-bookworm
+docker pull ppiper/node-browsers:24-trixie
 docker pull ppiper/node-browsers:26-trixie
 ```
 
@@ -45,7 +47,7 @@ To build this image locally, open a terminal in the directory of the Dockerfile 
 docker build --build-arg=BASE_IMAGE_TAG=26-trixie -t ppiper/node-browsers .
 ```
 
-Where the `BASE_IMAGE_TAG` can be set to `20-bookworm`, `22-bookworm`, `24-bookworm`, or `26-trixie`.
+Where the `BASE_IMAGE_TAG` can be set to `20-bookworm`, `22-bookworm`, `22-trixie`, `24-bookworm`, `24-trixie`, or `26-trixie`.
 The given tag **must** exist in the [node](https://hub.docker.com/_/node) base image **and** use Debian GNU/Linux.
 
 ## Usage


### PR DESCRIPTION
Adds 22-trixie and 24-trixie alongside existing bookworm versions. Bookworm images remain available until Node 22 and 24 reach end of maintenance.